### PR TITLE
Batch API calls

### DIFF
--- a/src/main/java/com/logtail/logback/LogtailAppender.java
+++ b/src/main/java/com/logtail/logback/LogtailAppender.java
@@ -328,4 +328,10 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     public boolean isDisabled() {
         return this.disabled;
     }
+
+    @Override
+    public void stop() {
+        flush();
+        super.stop();
+    }
 }

--- a/src/main/java/com/logtail/logback/LogtailAppender.java
+++ b/src/main/java/com/logtail/logback/LogtailAppender.java
@@ -1,15 +1,14 @@
 package com.logtail.logback;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
-import java.lang.StackTraceElement;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -19,23 +18,14 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-
-import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
  * Logback appender for sending logs to <a href="https://logtail.com">logtail.com</a>.
- * 
+ *
  * @author tomas@logtail.com
  */
 public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
@@ -67,6 +57,11 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     protected long connectTimeout = 5000;
 
     protected long readTimeout = 10000;
+
+    private int batchSize = 1000;
+
+    private List<ILoggingEvent> batch = new ArrayList<>();
+
 
     /**
      * Appender initialization.
@@ -115,8 +110,21 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
             return;
         }
 
+        appendToBatch(event);
+
+    }
+
+    private void appendToBatch(ILoggingEvent event) {
+        batch.add(event);
+
+        if (batch.size() >= batchSize) {
+            flush();
+        }
+    }
+
+    protected void flush() {
         try {
-            String jsonData = convertLogEventToJson(event);
+            String jsonData = convertLogEventsToJson(batch);
 
             Response response = callIngestApi(jsonData);
 
@@ -125,17 +133,20 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
                 errorLog.error("Error calling Logtail : {} ({})", logtailResponse.getError(), response.getStatus());
             }
 
+            batch.clear();
         } catch (JsonProcessingException e) {
             errorLog.error("Error processing JSON data : {}", e.getMessage());
 
         } catch (Exception e) {
             errorLog.error("Error trying to call Logtail : {}", e.getMessage());
         }
-
     }
 
-    protected String convertLogEventToJson(ILoggingEvent event) throws JsonProcessingException {
-        return this.dataMapper.writeValueAsString(buildPostData(event));
+    protected String convertLogEventsToJson(List<ILoggingEvent> events) throws JsonProcessingException {
+        List<Map<String, Object>> values = events.stream()
+                .map(this::buildPostData)
+                .collect(Collectors.toList());
+        return this.dataMapper.writeValueAsString(values);
     }
 
     protected LogtailResponse convertResponseToObject(Response response) throws JsonProcessingException {
@@ -144,7 +155,7 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
     /**
      * Call Logtail API posting given JSON formated string.
-     * 
+     *
      * @param jsonData
      *            a json oriented map
      * @return the http response
@@ -158,12 +169,12 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
     /**
      * Converts a logback logging event to a JSON oriented array.
-     * 
+     *
      * @param event
      *            the logging event
      * @return a json oriented array
      */
-    protected ArrayList<Object> buildPostData(ILoggingEvent event) {
+    protected Map<String, Object> buildPostData(ILoggingEvent event) {
         Map<String, Object> line = new HashMap<>();
 
         line.put("dt", Long.toString(event.getTimeStamp()));
@@ -201,10 +212,7 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         }
         line.put("runtime", runtime);
 
-        ArrayList<Object> lines = new ArrayList<>();
-        lines.add(line);
-
-        return lines;
+        return line;
     }
 
     private Object getMetaValue(String type, String value) {
@@ -231,7 +239,7 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
     /**
      * Sets your Logtail ingest API key.
-     * 
+     *
      * @param ingestKey
      *            your ingest key
      */
@@ -241,7 +249,7 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
     /**
      * Sets the application name for Logtail indexation.
-     * 
+     *
      * @param appName
      *            application name
      */
@@ -251,7 +259,7 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
     /**
      * Sets the Logtail ingest API url.
-     * 
+     *
      * @param ingestUrl
      *            Logtail url
      */
@@ -261,7 +269,7 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
     /**
      * Sets the MDC fields that needs to be sent inside Logtail metadata, separated by a comma.
-     * 
+     *
      * @param mdcFields
      *            MDC fields to use
      */
@@ -272,7 +280,7 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     /**
      * Sets the MDC fields types that will be sent inside Logtail metadata, in the same order as <i>mdcFields</i> are set
      * up, separated by a comma. Possible values are <i>string</i>, <i>boolean</i>, <i>int</i> and <i>long</i>.
-     * 
+     *
      * @param mdcTypes
      *            MDC fields types
      */
@@ -282,7 +290,7 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
     /**
      * Sets the connection timeout of the underlying HTTP client, in milliseconds.
-     * 
+     *
      * @param connectTimeout
      *            client connection timeout
      */
@@ -292,12 +300,29 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
     /**
      * Sets the read timeout of the underlying HTTP client, in milliseconds.
-     * 
+     *
      * @param readTimeout
      *            client read timeout
      */
     public void setReadTimeout(Long readTimeout) {
         this.readTimeout = readTimeout;
+    }
+
+    /**
+     * Sets the batch size for the number of messages to be sent via the API
+     *
+     * @param batchSize
+     *            size of the message batch
+     */
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    /**
+     * Get the size of the message batch
+     */
+    public int getBatchSize() {
+        return batchSize;
     }
 
     public boolean isDisabled() {

--- a/src/test/java/com/logtail/logback/LogtailAppenderBatchConfigSizeTest.java
+++ b/src/test/java/com/logtail/logback/LogtailAppenderBatchConfigSizeTest.java
@@ -33,8 +33,7 @@ public class LogtailAppenderBatchConfigSizeTest {
 
         JoranConfigurator configurator = new JoranConfigurator();
         configurator.setContext(loggerContext);
-//        configurator.doConfigure("src/test/resources/logback-batch-test.xml");
-        configurator.doConfigure("/Users/cosmin/work/3rdparty/logback-logtail/src/test/resources/logback-batch-test.xml");
+        configurator.doConfigure("src/test/resources/logback-batch-test.xml");
 
         Logger rootLogger = (Logger) LoggerFactory.getLogger("ROOT");
         AsyncAppender asyncAppender = (AsyncAppender) rootLogger.getAppender("Logtail");

--- a/src/test/java/com/logtail/logback/LogtailAppenderBatchConfigSizeTest.java
+++ b/src/test/java/com/logtail/logback/LogtailAppenderBatchConfigSizeTest.java
@@ -1,0 +1,82 @@
+package com.logtail.logback;
+
+import ch.qos.logback.classic.AsyncAppender;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.joran.spi.JoranException;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * ! One LOGTAIL_INGEST_KEY must be set as an environment variable before launching the test !
+ *
+ * @author tomas@logtail.com
+ */
+public class LogtailAppenderBatchConfigSizeTest {
+
+    private Logger logger = (Logger) LoggerFactory.getLogger(LogtailAppenderBatchConfigSizeTest.class);
+
+    private LogtailAppenderDecorator appender;
+
+    @Before
+    public void init() throws JoranException {
+        LoggerContext loggerContext = ((LoggerContext) LoggerFactory.getILoggerFactory());
+        loggerContext.reset();
+
+        JoranConfigurator configurator = new JoranConfigurator();
+        configurator.setContext(loggerContext);
+//        configurator.doConfigure("src/test/resources/logback-batch-test.xml");
+        configurator.doConfigure("/Users/cosmin/work/3rdparty/logback-logtail/src/test/resources/logback-batch-test.xml");
+
+        Logger rootLogger = (Logger) LoggerFactory.getLogger("ROOT");
+        AsyncAppender asyncAppender = (AsyncAppender) rootLogger.getAppender("Logtail");
+        appender = (LogtailAppenderDecorator) asyncAppender.getAppender("LogtailHttp");
+        assertEquals(200, appender.getBatchSize());
+    }
+
+    @Test
+    public void testBatchSizeFromConfig() throws Exception {
+        // This is to easily identify and diagnose messages coming from the same test run
+        String batchRunId = UUID.randomUUID().toString().toLowerCase().replace("-", "");
+
+        for (int i = 0; i < 100; i++) {
+            MDC.put("requestId", "testErrorLog");
+            MDC.put("requestTime", i + "");
+            this.logger.info(batchRunId + " Custom batch size Batch Groot " + i);
+            assertEquals(0, this.appender.apiCalls);
+        }
+        for (int i = 0; i < 99; i++) {
+            MDC.put("requestId", "testErrorLog");
+            MDC.put("requestTime", (100 + i) + "");
+            this.logger.info(batchRunId + " Custom batch sizeBatch Groot " + (100 + i));
+            assertEquals(0, this.appender.apiCalls);
+        }
+
+        MDC.put("requestId", "testErrorLog");
+        MDC.put("requestTime", 199 + "");
+        this.logger.info(batchRunId + " Custom batch size Final Batch Groot ");
+        Thread.sleep(2000);
+        assertEquals(1, this.appender.apiCalls);
+
+        isOk();
+    }
+
+    private void isOk() {
+        if (!appender.isOK() && appender.hasError()) {
+            System.out.println(appender.getLogtailResponse().getStatus() + " - " + appender.getLogtailResponse().getError());
+        }
+        if (!appender.isOK() && appender.hasException()) {
+            appender.getException().printStackTrace();
+        }
+        assertTrue(appender.isOK());
+    }
+
+}

--- a/src/test/java/com/logtail/logback/LogtailAppenderDecorator.java
+++ b/src/test/java/com/logtail/logback/LogtailAppenderDecorator.java
@@ -14,12 +14,15 @@ public class LogtailAppenderDecorator extends LogtailAppender {
 
     private LogtailResponse logtailResponse;
 
+    protected int apiCalls = 0;
+
     @Override
     protected Response callIngestApi(String jsonData) {
 
         try {
 
             this.response = super.callIngestApi(jsonData);
+            apiCalls++;
             return response;
 
         } catch (Throwable t) {

--- a/src/test/java/com/logtail/logback/LogtailAppenderShutdownTest.java
+++ b/src/test/java/com/logtail/logback/LogtailAppenderShutdownTest.java
@@ -1,0 +1,57 @@
+package com.logtail.logback;
+
+import ch.qos.logback.classic.AsyncAppender;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.joran.spi.JoranException;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * ! One LOGTAIL_INGEST_KEY must be set as an environment variable before launching the test !
+ *
+ * @author tomas@logtail.com
+ */
+public class LogtailAppenderShutdownTest {
+
+    private Logger logger = (Logger) LoggerFactory.getLogger(LogtailAppenderShutdownTest.class);
+
+    private LogtailAppenderDecorator appender;
+
+    @Before
+    public void init() throws JoranException {
+        LoggerContext loggerContext = ((LoggerContext) LoggerFactory.getILoggerFactory());
+        loggerContext.reset();
+
+        JoranConfigurator configurator = new JoranConfigurator();
+        configurator.setContext(loggerContext);
+        configurator.doConfigure("src/test/resources/logback-shutdown-test.xml");
+
+        Logger rootLogger = (Logger) LoggerFactory.getLogger("ROOT");
+        AsyncAppender asyncAppender = (AsyncAppender) rootLogger.getAppender("Logtail");
+        appender = (LogtailAppenderDecorator) asyncAppender.getAppender("LogtailHttp");
+        assertEquals(10, appender.getBatchSize());
+    }
+
+    @Test
+    public void testAppend() throws Exception {
+        // This is to easily identify and diagnose messages coming from the same test run
+        String batchRunId = UUID.randomUUID().toString().toLowerCase().replace("-", "");
+
+        for (int i = 0; i < 5; i++) {
+            MDC.put("requestId", "testErrorLog");
+            MDC.put("requestTime", i + "");
+            this.logger.info(batchRunId + " Shutdown hook test" + i);
+            assertEquals(0, this.appender.apiCalls);
+        }
+        Thread.sleep(2000);
+        assertEquals(0, this.appender.apiCalls);
+    }
+}

--- a/src/test/java/com/logtail/logback/LogtailAppenderTest.java
+++ b/src/test/java/com/logtail/logback/LogtailAppenderTest.java
@@ -1,23 +1,16 @@
 package com.logtail.logback;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Collection;
-import java.util.ArrayList;
-import java.util.Map;
-
-import org.junit.Test;
-import org.slf4j.MDC;
-
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
+import org.junit.Test;
+import org.slf4j.MDC;
+
+import java.util.Map;
+
+import static org.junit.Assert.*;
 
 public class LogtailAppenderTest {
 
@@ -35,7 +28,7 @@ public class LogtailAppenderTest {
         MDC.put("field5", "456");
 
         Logger logger = new LoggerContext().getLogger(Logger.ROOT_LOGGER_NAME);
-        ILoggingEvent ev = new LoggingEvent(Logger.FQCN, logger, Level.INFO, "My log message", null, new Object[] {});
+        ILoggingEvent ev = new LoggingEvent(Logger.FQCN, logger, Level.INFO, "My log message", null, new Object[]{});
 
         // Self instantiated appender
         LogtailAppender appender = new LogtailAppender();
@@ -44,14 +37,11 @@ public class LogtailAppenderTest {
         appender.setMdcTypes("string,int,boolean,long");
 
         // Build up future-JSON data
-        ArrayList<Object> postData = appender.buildPostData(ev);
+        Map<String, Object> postData = appender.buildPostData(ev);
 
         assertNotNull(postData);
-        assertEquals(1, postData.size());
-        assertNotNull(postData.get(0));
 
-        Map<String, Object> event = (Map<String, Object>) postData.get(0);
-        assertEventData(ev, event);
+        assertEventData(ev, postData);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/resources/logback-batch-test.xml
+++ b/src/test/resources/logback-batch-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="LogtailHttp" class="com.logtail.logback.LogtailAppender">
+    <appender name="LogtailHttp" class="com.logtail.logback.LogtailAppenderDecorator">
         <appName>LogtailTest</appName>
         <ingestKey>${LOGTAIL_INGEST_KEY}</ingestKey>
         <batchSize>200</batchSize>
@@ -11,7 +11,6 @@
 
     <appender name="Logtail" class="ch.qos.logback.classic.AsyncAppender">
         <appender-ref ref="LogtailHttp" />
-        <queueSize>500</queueSize>
         <discardingThreshold>0</discardingThreshold>
         <includeCallerData>true</includeCallerData>
     </appender>

--- a/src/test/resources/logback-shutdown-test.xml
+++ b/src/test/resources/logback-shutdown-test.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="LogtailHttp" class="com.logtail.logback.LogtailAppenderDecorator">
+        <appName>LogtailTest</appName>
+        <ingestKey>${LOGTAIL_INGEST_KEY}</ingestKey>
+        <batchSize>10</batchSize>
+        <mdcFields>requestId,requestTime</mdcFields>
+        <mdcTypes>string,int</mdcTypes>
+    </appender>
+
+    <appender name="Logtail" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="LogtailHttp" />
+        <discardingThreshold>0</discardingThreshold>
+        <includeCallerData>true</includeCallerData>
+    </appender>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm} %-5level %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="Logtail" />
+        <appender-ref ref="Console" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
This is a first implementation for batching API calls as per discussion here https://github.com/logtail/logback-logtail/issues/4.

Some notes:
* Batch size is configures using `<batchSize>200</batchSize>`, see `logback-batch-test.xml`
* Some tests require an explicit `flush()` in order to force the sending.
* There's a need for a `Thread.sleep(2000)` in `LogtailAppenderBatchConfigSizeTest`
* We recommend not suggesting `queueSize` in the documentation as to not create confusion with `batchSize`