### PR TITLE
Improve CI checks

### DIFF
--- a/.github/workflows/java_build.yaml
+++ b/.github/workflows/java_build.yaml
@@ -23,7 +23,7 @@ jobs:
 
       steps:
       -  name: Checkout project
-         uses: actions/checkout@v2
+         uses: actions/checkout@v3
          with:
             fetch-depth: 0
       -  name: Set up JDK

--- a/.github/workflows/java_build.yaml
+++ b/.github/workflows/java_build.yaml
@@ -8,9 +8,19 @@ on:
       - opened
       - synchronize
       - reopened
+   schedule:
+      - cron: '20 5 * * 1'
+   workflow_dispatch:
+
 jobs:
    build:
       runs-on: ubuntu-latest
+
+      strategy:
+         matrix:
+            java-version: [ 8, 11, 17, 20 ]
+         fail-fast: false
+
       steps:
       -  name: Checkout project
          uses: actions/checkout@v2
@@ -19,22 +29,14 @@ jobs:
       -  name: Set up JDK
          uses: actions/setup-java@v1
          with:
-            java-version: 8
+            java-version: ${{ matrix.java-version }}
       -  name: Cache Maven packages
          uses: actions/cache@v1
          with:
             path: ~/.m2
-            key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+            key: ${{ runner.os }}-m2-java${{ matrix.java-version }}-${{ hashFiles('**/pom.xml') }}
             restore-keys: ${{ runner.os }}-m2
-      -  name: Build with Maven on Java 8
-         run: mvn -B clean package --file pom.xml
-         env:
-            BETTER_STACK_SOURCE_TOKEN: ${{ secrets.BETTER_STACK_SOURCE_TOKEN }}
-      -  name: Set up JDK
-         uses: actions/setup-java@v1
-         with:
-            java-version: 11
-      -  name: Build with Maven on Java 8
+      -  name: Build with Maven
          run: mvn -B clean package --file pom.xml
          env:
             BETTER_STACK_SOURCE_TOKEN: ${{ secrets.BETTER_STACK_SOURCE_TOKEN }}


### PR DESCRIPTION
Run tests for all LTS versions of Java (8, 11, 17) and for the current version (20). See [Java version history](https://en.wikipedia.org/wiki/Java_version_history) on wiki for details. Also, it will be clear which versions pass and which fail because of the test matrix.

Run tests weekly to see whether new versions of dependencies have not broke the build.

Enable workflow dispatch to start tests manually on any branch.

---

_Due to the nature of integration tests we currently have, this will increase loads on our server (~1200 logs per test run and Java version). I think this increase is totally acceptable._