### PR TITLE
Include stack traces and arguments in logs sent to Better Stack

### DIFF
--- a/examples/gradle/README.md
+++ b/examples/gradle/README.md
@@ -3,5 +3,5 @@
 * Get your source token at [Better Stack -> Sources](http://logs.betterstack.com/team/0/sources).
 * Edit [src/main/resources/logback.xml](src/main/resources/logback.xml) and replace `<!-- YOUR SOURCE TOKEN -->` with your source token.
 * Run `gradle run` from this directory.
-* You should see a `Hello world` log in [Better Stack -> Live tail](https://logs.betterstack.com/team/0/tail).
+* You should see a `Hello World!` log along with a few other examples in [Better Stack -> Live tail](https://logs.betterstack.com/team/0/tail).
 

--- a/examples/gradle/src/main/java/com/logtail/example/App.java
+++ b/examples/gradle/src/main/java/com/logtail/example/App.java
@@ -4,8 +4,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
+import java.awt.Point;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
+import java.util.Random;
 import java.util.UUID;
 
 public class App {
@@ -15,7 +17,20 @@ public class App {
         MDC.put("requestId", UUID.randomUUID().toString());
         MDC.put("requestTime", Long.toString(Instant.now().getEpochSecond()));
 
-        logger.info("hello world");
+        logger.info("Hello World!");
+
+        Random coordinateGenerator = new Random();
+        logger.info("Point A", new Point(coordinateGenerator.nextInt(1024), coordinateGenerator.nextInt(1024)));
+        logger.info("Point B", new Point(coordinateGenerator.nextInt(1024), coordinateGenerator.nextInt(1024)));
+        logger.info("Point C", new Point(coordinateGenerator.nextInt(1024), coordinateGenerator.nextInt(1024)));
+
+        logger.info("Snow White met a few dwarfs.", "Doc", "Sleepy", "Dopey", "Grumpy", "Happy", "Bashful", "Sneezy");
+
+        try {
+            throw new RuntimeException("An error occurred.", new Exception("The original cause."));
+        } catch (RuntimeException exception) {
+            logger.error("Logging a thrown exception.", exception);
+        }
 
         try {
             TimeUnit.SECONDS.sleep(5);

--- a/examples/gradle/src/main/java/com/logtail/example/App.java
+++ b/examples/gradle/src/main/java/com/logtail/example/App.java
@@ -6,12 +6,13 @@ import org.slf4j.MDC;
 
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
+import java.util.UUID;
 
 public class App {
     public static void main(String[] args) {
         Logger logger = LoggerFactory.getLogger(App.class);
 
-        MDC.put("requestId", "stringValue");
+        MDC.put("requestId", UUID.randomUUID().toString());
         MDC.put("requestTime", Long.toString(Instant.now().getEpochSecond()));
 
         logger.info("hello world");

--- a/examples/gradle/src/main/java/com/logtail/example/App.java
+++ b/examples/gradle/src/main/java/com/logtail/example/App.java
@@ -2,12 +2,18 @@ package com.logtail.example;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
+import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
 public class App {
     public static void main(String[] args) {
         Logger logger = LoggerFactory.getLogger(App.class);
+
+        MDC.put("requestId", "stringValue");
+        MDC.put("requestTime", Long.toString(Instant.now().getEpochSecond()));
+
         logger.info("hello world");
 
         try {

--- a/examples/maven/README.md
+++ b/examples/maven/README.md
@@ -3,4 +3,4 @@
 * Get your source token at [Better Stack -> Sources](http://logs.betterstack.com/team/0/sources).
 * Edit [src/main/resources/logback.xml](src/main/resources/logback.xml) and replace `<!-- YOUR SOURCE TOKEN -->` with your source token.
 * Run `mvn compile -e exec:java -Dexec.mainClass="com.logtail.example.App"` from this directory.
-* You should see a "Hello world" log in [Better Stack -> Live tail](https://logs.betterstack.com/team/0/tail).
+* You should see a `Hello World!` log along with a few other examples in [Better Stack -> Live tail](https://logs.betterstack.com/team/0/tail).

--- a/examples/maven/src/main/java/com/logtail/example/App.java
+++ b/examples/maven/src/main/java/com/logtail/example/App.java
@@ -5,12 +5,13 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import java.time.Instant;
+import java.util.UUID;
 
 public class App {
     public static void main(String[] args) {
         Logger logger = LoggerFactory.getLogger(App.class);
 
-        MDC.put("requestId", "stringValue");
+        MDC.put("requestId", UUID.randomUUID().toString());
         MDC.put("requestTime", Long.toString(Instant.now().getEpochSecond()));
 
         logger.info("hello world");

--- a/examples/maven/src/main/java/com/logtail/example/App.java
+++ b/examples/maven/src/main/java/com/logtail/example/App.java
@@ -4,7 +4,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
+import java.awt.Point;
 import java.time.Instant;
+import java.util.Random;
 import java.util.UUID;
 
 public class App {
@@ -14,6 +16,19 @@ public class App {
         MDC.put("requestId", UUID.randomUUID().toString());
         MDC.put("requestTime", Long.toString(Instant.now().getEpochSecond()));
 
-        logger.info("hello world");
+        logger.info("Hello World!");
+
+        Random coordinateGenerator = new Random();
+        logger.info("Point A", new Point(coordinateGenerator.nextInt(1024), coordinateGenerator.nextInt(1024)));
+        logger.info("Point B", new Point(coordinateGenerator.nextInt(1024), coordinateGenerator.nextInt(1024)));
+        logger.info("Point C", new Point(coordinateGenerator.nextInt(1024), coordinateGenerator.nextInt(1024)));
+
+        logger.info("Snow White met a few dwarfs.", "Doc", "Sleepy", "Dopey", "Grumpy", "Happy", "Bashful", "Sneezy");
+
+        try {
+            throw new RuntimeException("An error occurred.", new Exception("The original cause."));
+        } catch (RuntimeException exception) {
+            logger.error("Logging a thrown exception.", exception);
+        }
     }
 }

--- a/examples/maven/src/main/java/com/logtail/example/App.java
+++ b/examples/maven/src/main/java/com/logtail/example/App.java
@@ -2,10 +2,17 @@ package com.logtail.example;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.time.Instant;
 
 public class App {
     public static void main(String[] args) {
         Logger logger = LoggerFactory.getLogger(App.class);
+
+        MDC.put("requestId", "stringValue");
+        MDC.put("requestTime", Long.toString(Instant.now().getEpochSecond()));
+
         logger.info("hello world");
     }
 }

--- a/src/main/java/com/logtail/logback/LogtailAppender.java
+++ b/src/main/java/com/logtail/logback/LogtailAppender.java
@@ -2,6 +2,7 @@ package com.logtail.logback;
 
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -183,6 +184,10 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         logLine.put("message", generateLogMessage(event));
         logLine.put("meta", generateLogMeta(event));
         logLine.put("runtime", generateLogRuntime(event));
+        logLine.put("args", event.getArgumentArray());
+        if (event.getThrowableProxy() != null) {
+            logLine.put("throwable", generateLogThrowable(event.getThrowableProxy()));
+        }
 
         return logLine;
     }
@@ -225,6 +230,18 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         }
 
         return logRuntime;
+    }
+
+    protected Map<String, Object> generateLogThrowable(IThrowableProxy throwable) {
+        Map<String, Object> logThrowable = new HashMap<>();
+        logThrowable.put("message", throwable.getMessage());
+        logThrowable.put("class", throwable.getClassName());
+        logThrowable.put("stackTrace", throwable.getStackTraceElementProxyArray());
+        if (throwable.getCause() != null) {
+            logThrowable.put("cause", generateLogThrowable(throwable.getCause()));
+        }
+
+        return logThrowable;
     }
 
     protected Object getMetaValue(String type, String value) {


### PR DESCRIPTION
Includes arguments and logged exceptions with stack traced in the data sent to Better Stack.

Extends example usage with the newly supported data (and usage of `org.slf4j.MDC` which we've already supported)

I'm planning on releasing this as `0.3.1`

<img width="1778" alt="image" src="https://github.com/logtail/logback-logtail/assets/10008612/96dcc0a1-c8ae-46da-b10a-dc26dd183080">
