### PR TITLE
L-849 Send logs in configured batches, repeat sending unsuccessful data

### DIFF
--- a/src/main/java/com/logtail/logback/LogtailAppender.java
+++ b/src/main/java/com/logtail/logback/LogtailAppender.java
@@ -133,12 +133,12 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
             LogtailResponse response = callHttpURLConnection(flushedSize);
 
-            if (response.getStatus() != 202) {
+            if (response.getStatus() == 202) {
+                batch.subList(0, flushedSize).clear();
+                this.warnAboutMaxQueueSize = true;
+            } else {
                 errorLog.error("Error calling Better Stack : {} ({})", response.getError(), response.getStatus());
             }
-
-            batch.subList(0, flushedSize).clear();
-            this.warnAboutMaxQueueSize = true;
         } catch (JsonProcessingException e) {
             errorLog.error("Error processing JSON data : {}", e.getMessage(), e);
 

--- a/src/main/java/com/logtail/logback/LogtailAppender.java
+++ b/src/main/java/com/logtail/logback/LogtailAppender.java
@@ -129,7 +129,7 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         this.mustReflush = false;
 
         try {
-            int flushedSize = batch.size();
+            int flushedSize = Math.min(batch.size(), batchSize);
 
             LogtailResponse response = callHttpURLConnection(flushedSize);
 

--- a/src/main/java/com/logtail/logback/LogtailAppender.java
+++ b/src/main/java/com/logtail/logback/LogtailAppender.java
@@ -133,7 +133,7 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
             LogtailResponse response = callHttpURLConnection(flushedSize);
 
-            if (response.getStatus() == 202) {
+            if (response.getStatus() >= 200 && response.getStatus() < 300) {
                 batch.subList(0, flushedSize).clear();
                 this.warnAboutMaxQueueSize = true;
             } else {


### PR DESCRIPTION
While testing #17 I've noticed the LogtailAppender will discard any logs that were sent to Better Stack, even if there was a non-202 status code. Also, the `batchSize` is not fully respected ("batch size for the number of messages to be sent via the API"), as it will always send all currently queued logs.

Better Stack is not able to accept large chucks of data in a single request (I've noticed some 500 responses for 100k of non-trivial logs).

This would mean our users could lose their data if their log queue got too full.
