### PR TITLE
L-849 Limit max number of retries for sending logs

### DIFF
--- a/src/main/java/com/logtail/logback/LogtailAppender.java
+++ b/src/main/java/com/logtail/logback/LogtailAppender.java
@@ -343,6 +343,9 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
                 flush();
             } catch (Exception e) {
                 logger.error("Error trying to flush : {}", e.getMessage(), e);
+                if (isFlushing.get()) {
+                    isFlushing.set(false);
+                }
             }
         }
     }


### PR DESCRIPTION
Adds 2 new options: `maxRetries` and `retrySleepMilliseconds`

Previously, logger would be stuck sending the same batch over and over if - for some reason - it couldn't be accepted by Better Stack. Now, it will retry a few times and then drop the batch.