### PR TITLE
L-1336 Remove AsyncAppender from config

### DIFF
--- a/examples/gradle/src/main/resources/logback.xml
+++ b/examples/gradle/src/main/resources/logback.xml
@@ -1,20 +1,17 @@
 <configuration debug="true">
-    <appender name="LogtailHttp" class="com.logtail.logback.LogtailAppender">
+    <appender name="Logtail" class="com.logtail.logback.LogtailAppender">
         <appName>Better Stack Gradle example app</appName>
-        <batchSize>1</batchSize>
         <sourceToken><!-- YOUR SOURCE TOKEN --></sourceToken>
         <mdcFields>requestId,requestTime</mdcFields>
         <mdcTypes>string,int</mdcTypes>
     </appender>
 
-    <appender name="Logtail" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="LogtailHttp" />
-        <queueSize>1</queueSize>
-        <discardingThreshold>0</discardingThreshold>
-        <includeCallerData>true</includeCallerData>
-    </appender>
-
-    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %msg%n</pattern>
         </encoder>

--- a/examples/gradle/src/main/resources/logback.xml
+++ b/examples/gradle/src/main/resources/logback.xml
@@ -6,12 +6,7 @@
         <mdcTypes>string,int</mdcTypes>
     </appender>
 
-    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">>
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>ERROR</level>
-            <onMatch>ACCEPT</onMatch>
-            <onMismatch>DENY</onMismatch>
-        </filter>
+     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %msg%n</pattern>
         </encoder>

--- a/examples/maven/src/main/resources/logback.xml
+++ b/examples/maven/src/main/resources/logback.xml
@@ -1,16 +1,9 @@
 <configuration debug="true">
-    <appender name="LogtailHttp" class="com.logtail.logback.LogtailAppender">
+    <appender name="Logtail" class="com.logtail.logback.LogtailAppender">
         <appName>Better Stack Maven example app</appName>
         <sourceToken><!-- YOUR SOURCE TOKEN --></sourceToken>
         <mdcFields>requestId,requestTime</mdcFields>
         <mdcTypes>string,int</mdcTypes>
-    </appender>
-
-    <appender name="Logtail" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="LogtailHttp" />
-        <queueSize>1</queueSize>
-        <discardingThreshold>0</discardingThreshold>
-        <includeCallerData>true</includeCallerData>
     </appender>
 
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">

--- a/src/test/java/com/logtail/logback/LogtailAppenderBatchConfigSizeTest.java
+++ b/src/test/java/com/logtail/logback/LogtailAppenderBatchConfigSizeTest.java
@@ -1,6 +1,5 @@
 package com.logtail.logback;
 
-import ch.qos.logback.classic.AsyncAppender;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
@@ -36,8 +35,7 @@ public class LogtailAppenderBatchConfigSizeTest {
         configurator.doConfigure("src/test/resources/logback-batch-test.xml");
 
         Logger rootLogger = (Logger) LoggerFactory.getLogger("ROOT");
-        AsyncAppender asyncAppender = (AsyncAppender) rootLogger.getAppender("Logtail");
-        appender = (LogtailAppenderDecorator) asyncAppender.getAppender("LogtailHttp");
+        LogtailAppenderDecorator appender = (LogtailAppenderDecorator) rootLogger.getAppender("Logtail");
         assertEquals(200, appender.getBatchSize());
     }
 

--- a/src/test/java/com/logtail/logback/LogtailAppenderBatchConfigSizeTest.java
+++ b/src/test/java/com/logtail/logback/LogtailAppenderBatchConfigSizeTest.java
@@ -35,7 +35,7 @@ public class LogtailAppenderBatchConfigSizeTest {
         configurator.doConfigure("src/test/resources/logback-batch-test.xml");
 
         Logger rootLogger = (Logger) LoggerFactory.getLogger("ROOT");
-        LogtailAppenderDecorator appender = (LogtailAppenderDecorator) rootLogger.getAppender("Logtail");
+        appender = (LogtailAppenderDecorator) rootLogger.getAppender("Logtail");
         assertEquals(200, appender.getBatchSize());
     }
 

--- a/src/test/java/com/logtail/logback/LogtailAppenderShutdownTest.java
+++ b/src/test/java/com/logtail/logback/LogtailAppenderShutdownTest.java
@@ -34,7 +34,7 @@ public class LogtailAppenderShutdownTest {
         configurator.doConfigure("src/test/resources/logback-shutdown-test.xml");
 
         Logger rootLogger = (Logger) LoggerFactory.getLogger("ROOT");
-        LogtailAppenderDecorator appender = (LogtailAppenderDecorator) rootLogger.getAppender("Logtail");
+        appender = (LogtailAppenderDecorator) rootLogger.getAppender("Logtail");
         assertEquals(10, appender.getBatchSize());
     }
 

--- a/src/test/java/com/logtail/logback/LogtailAppenderShutdownTest.java
+++ b/src/test/java/com/logtail/logback/LogtailAppenderShutdownTest.java
@@ -1,6 +1,5 @@
 package com.logtail.logback;
 
-import ch.qos.logback.classic.AsyncAppender;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
@@ -35,8 +34,7 @@ public class LogtailAppenderShutdownTest {
         configurator.doConfigure("src/test/resources/logback-shutdown-test.xml");
 
         Logger rootLogger = (Logger) LoggerFactory.getLogger("ROOT");
-        AsyncAppender asyncAppender = (AsyncAppender) rootLogger.getAppender("Logtail");
-        appender = (LogtailAppenderDecorator) asyncAppender.getAppender("LogtailHttp");
+        LogtailAppenderDecorator appender = (LogtailAppenderDecorator) rootLogger.getAppender("Logtail");
         assertEquals(10, appender.getBatchSize());
     }
 

--- a/src/test/java/com/logtail/logback/LogtailAppenderXmlConfigTest.java
+++ b/src/test/java/com/logtail/logback/LogtailAppenderXmlConfigTest.java
@@ -8,7 +8,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 
-import ch.qos.logback.classic.AsyncAppender;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
@@ -35,10 +34,8 @@ public class LogtailAppenderXmlConfigTest {
     public void testLogtailAppenderConfiguration() {
 
         Logger rootLogger = (Logger) LoggerFactory.getLogger("ROOT");
-        AsyncAppender asyncAppender = (AsyncAppender) rootLogger.getAppender("Logtail");
-        assertNotNull("Logtail AsyncAppender not found, meaning that the xmlConfig property set up failed", asyncAppender);
 
-        LogtailAppender appender = (LogtailAppender) asyncAppender.getAppender("LogtailHttp");
+        LogtailAppender appender = (LogtailAppender) rootLogger.getAppender("Logtail");
         assertNotNull(appender);
 
         assertNotNull(appender.ingestUrl);

--- a/src/test/java/com/logtail/logback/LogtailAppenderXmlEmptyConfigTest.java
+++ b/src/test/java/com/logtail/logback/LogtailAppenderXmlEmptyConfigTest.java
@@ -31,7 +31,7 @@ public class LogtailAppenderXmlEmptyConfigTest {
     public void testLogtailAppenderConfiguration() {
         Logger rootLogger = (Logger) LoggerFactory.getLogger("ROOT");
 
-        LogtailAppender appender = (LogtailAppender) rootLogger.getAppender("LogtailHttp");
+        LogtailAppender appender = (LogtailAppender) rootLogger.getAppender("Logtail");
         assertNotNull(appender);
         
         rootLogger.info("I am Groot");

--- a/src/test/resources/logback-batch-test.xml
+++ b/src/test/resources/logback-batch-test.xml
@@ -1,18 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="LogtailHttp" class="com.logtail.logback.LogtailAppenderDecorator">
+    <appender name="Logtail" class="com.logtail.logback.LogtailAppenderDecorator">
         <appName>BetterStackTest</appName>
         <sourceToken>${BETTER_STACK_SOURCE_TOKEN}</sourceToken>
         <batchSize>200</batchSize>
         <mdcFields>requestId,requestTime</mdcFields>
         <mdcTypes>string,int</mdcTypes>
-    </appender>
-
-    <appender name="Logtail" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="LogtailHttp" />
-        <discardingThreshold>0</discardingThreshold>
-        <includeCallerData>true</includeCallerData>
     </appender>
 
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">

--- a/src/test/resources/logback-disabled.xml
+++ b/src/test/resources/logback-disabled.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="LogtailHttp" class="com.logtail.logback.LogtailAppender">
+    <appender name="Logtail" class="com.logtail.logback.LogtailAppender">
         <encoder>
             <pattern>[%thread] %msg%n</pattern>
         </encoder>
@@ -12,7 +12,7 @@
     </appender>
 
     <root level="INFO">
-        <appender-ref ref="LogtailHttp" />
+        <appender-ref ref="Logtail" />
     </root>
 
 </configuration>

--- a/src/test/resources/logback-legacy-ingest-key.xml
+++ b/src/test/resources/logback-legacy-ingest-key.xml
@@ -1,18 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="LogtailHttp" class="com.logtail.logback.LogtailAppenderDecorator">
+    <appender name="Logtail" class="com.logtail.logback.LogtailAppenderDecorator">
         <appName>BetterStackTest</appName>
         <ingestKey>${BETTER_STACK_SOURCE_TOKEN}</ingestKey>
         <batchSize>200</batchSize>
         <mdcFields>requestId,requestTime</mdcFields>
         <mdcTypes>string,int</mdcTypes>
-    </appender>
-
-    <appender name="Logtail" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="LogtailHttp" />
-        <discardingThreshold>0</discardingThreshold>
-        <includeCallerData>true</includeCallerData>
     </appender>
 
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">

--- a/src/test/resources/logback-prod.xml
+++ b/src/test/resources/logback-prod.xml
@@ -1,19 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="LogtailHttp" class="com.logtail.logback.LogtailAppender">
+    <appender name="Logtail" class="com.logtail.logback.LogtailAppender">
         <appName>BetterStackTest</appName>
         <sourceToken>${BETTER_STACK_SOURCE_TOKEN}</sourceToken>
         <batchSize>200</batchSize>
         <mdcFields>requestId,requestTime</mdcFields>
         <mdcTypes>string,int</mdcTypes>
-    </appender>
-
-    <appender name="Logtail" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="LogtailHttp" />
-        <queueSize>500</queueSize>
-        <discardingThreshold>0</discardingThreshold>
-        <includeCallerData>true</includeCallerData>
     </appender>
 
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">

--- a/src/test/resources/logback-shutdown-test.xml
+++ b/src/test/resources/logback-shutdown-test.xml
@@ -1,18 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="LogtailHttp" class="com.logtail.logback.LogtailAppenderDecorator">
+    <appender name="Logtail" class="com.logtail.logback.LogtailAppenderDecorator">
         <appName>BetterStackTest</appName>
         <sourceToken>${BETTER_STACK_SOURCE_TOKEN}</sourceToken>
         <batchSize>10</batchSize>
         <mdcFields>requestId,requestTime</mdcFields>
         <mdcTypes>string,int</mdcTypes>
-    </appender>
-
-    <appender name="Logtail" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="LogtailHttp" />
-        <discardingThreshold>0</discardingThreshold>
-        <includeCallerData>true</includeCallerData>
     </appender>
 
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
`AsyncAppender` was previously configured to avoid main thread waiting for flushing. However, flushing is done in a separate thread for a while now, so there should be no need for it anymore.