### PR TITLE
L-1103 Allow registering custom serialization modules

### DIFF
--- a/examples/gradle/build.gradle
+++ b/examples/gradle/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation 'ch.qos.logback:logback-classic:1.2.11'
     implementation 'ch.qos.logback:logback-core:1.2.11'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.5'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.5'
     implementation 'org.slf4j:slf4j-api:1.7.7'
 }
 

--- a/examples/gradle/src/main/java/com/logtail/example/App.java
+++ b/examples/gradle/src/main/java/com/logtail/example/App.java
@@ -6,6 +6,7 @@ import org.slf4j.MDC;
 
 import java.awt.Point;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 import java.util.Random;
 import java.util.UUID;
@@ -31,6 +32,8 @@ public class App {
         } catch (RuntimeException exception) {
             logger.error("Logging a thrown exception.", exception);
         }
+
+        logger.info("Logging local datetime serialized via JavaTimeModule.", LocalDateTime.now());
 
         try {
             TimeUnit.SECONDS.sleep(5);

--- a/examples/gradle/src/main/resources/logback.xml
+++ b/examples/gradle/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
         <objectMapperModule>com.fasterxml.jackson.datatype.jsr310.JavaTimeModule</objectMapperModule>
     </appender>
 
-     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %msg%n</pattern>
         </encoder>

--- a/examples/gradle/src/main/resources/logback.xml
+++ b/examples/gradle/src/main/resources/logback.xml
@@ -4,6 +4,7 @@
         <sourceToken><!-- YOUR SOURCE TOKEN --></sourceToken>
         <mdcFields>requestId,requestTime</mdcFields>
         <mdcTypes>string,int</mdcTypes>
+        <objectMapperModule>com.fasterxml.jackson.datatype.jsr310.JavaTimeModule</objectMapperModule>
     </appender>
 
      <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">

--- a/examples/maven/pom.xml
+++ b/examples/maven/pom.xml
@@ -44,6 +44,11 @@
             <version>2.13.5</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.13.5</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.7</version>

--- a/examples/maven/src/main/java/com/logtail/example/App.java
+++ b/examples/maven/src/main/java/com/logtail/example/App.java
@@ -6,6 +6,7 @@ import org.slf4j.MDC;
 
 import java.awt.Point;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Random;
 import java.util.UUID;
 
@@ -30,5 +31,7 @@ public class App {
         } catch (RuntimeException exception) {
             logger.error("Logging a thrown exception.", exception);
         }
+
+        logger.info("Logging local datetime serialized via JavaTimeModule.", LocalDateTime.now());
     }
 }

--- a/examples/maven/src/main/resources/logback.xml
+++ b/examples/maven/src/main/resources/logback.xml
@@ -4,6 +4,7 @@
         <sourceToken><!-- YOUR SOURCE TOKEN --></sourceToken>
         <mdcFields>requestId,requestTime</mdcFields>
         <mdcTypes>string,int</mdcTypes>
+        <objectMapperModule>com.fasterxml.jackson.datatype.jsr310.JavaTimeModule</objectMapperModule>
     </appender>
 
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">

--- a/src/main/java/com/logtail/logback/LogtailAppender.java
+++ b/src/main/java/com/logtail/logback/LogtailAppender.java
@@ -6,6 +6,7 @@ import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import org.slf4j.Logger;
@@ -497,6 +498,22 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
      */
     public void setRetrySleepMilliseconds(int retrySleepMilliseconds) {
         this.retrySleepMilliseconds = retrySleepMilliseconds;
+    }
+
+    /**
+     * Registers a dynamically loaded Module object to ObjectMapper used for serialization of logged data.
+     *
+     * @param className
+     *            fully qualified class name of the module, eg. "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule"
+     */
+    public void setObjectMapperModule(String className) {
+        try {
+            Module module = (Module) Class.forName(className).newInstance();
+            dataMapper.registerModule(module);
+            logger.info("Module '{}' successfully registered in ObjectMapper.", className);
+        } catch (ClassNotFoundException|InstantiationException|IllegalAccessException e) {
+            logger.error("Module '{}' couldn't be registered in ObjectMapper : ", className, e);
+        }
     }
 
     public void setEncoder(PatternLayoutEncoder encoder) {


### PR DESCRIPTION
Allows registering modules for serialization into ObjectMapper via XML, with examples in example project.

This can enable eg. serialization of `java.time.LocalDate` using the `com.fasterxml.jackson.datatype.jsr310.JavaTimeModule`. Multiple modules can be loaded via multiple `<objectMapperModule>` tags.