### PR TITLE
Disable SerializationFeature.FAIL_ON_EMPTY_BEANS in dataMapper

### DIFF
--- a/src/main/java/com/logtail/logback/LogtailAppender.java
+++ b/src/main/java/com/logtail/logback/LogtailAppender.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +76,8 @@ public class LogtailAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
         dataMapper = new ObjectMapper()
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                .setPropertyNamingStrategy(PropertyNamingStrategies.UPPER_CAMEL_CASE);
+                .setPropertyNamingStrategy(PropertyNamingStrategies.UPPER_CAMEL_CASE)
+                .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
 
         scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(threadFactory);
         scheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(new LogtailSender(), batchInterval, batchInterval, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Avoids errors when objects without serializable properties is logged, eg.:

```
Error processing JSON data : No serializer found for class org.postgresql.core.v3.replication.V3ReplicationProtocol and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain: java.util.ArrayList[1]->java.util.HashMap["args"]->org.postgresql.jdbc.PgConnection[1]->org.postgresql.jdbc.PgConnection["QueryExecutor"]->org.postgresql.core.v3.QueryExecutorImpl["ReplicationProtocol"])
```

Disabling it seems like a reasonable default in our case (better than dropping logs).

---

Tested with by logging a dummy object: `logger.info("Logging empty beans.", new NoPropertiesBean());`

```java
    // A class with no properties that Jackson can serialize.
    // It doesn't have public fields, nor does it have any getter methods.
    private static class NoPropertiesBean {
        private int id; // Private field without a getter method.

        public NoPropertiesBean() {
            this.id = 1; // The constructor sets the value, but it's not accessible for Jackson.
        }
    }
```

Gets logged as an empty object `{}`:

<img width="1063" alt="image" src="https://github.com/logtail/logback-logtail/assets/10008612/31722197-3f3b-4282-a1de-3a60d8fa9a1a">
