### PR TITLE
T-11913 Avoid ConcurrentModificationException under heavy loads

### DIFF
--- a/examples/gradle/build.gradle
+++ b/examples/gradle/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    implementation files('../../target/logback-logtail-0.3.4.jar')
+    implementation files('../../target/logback-logtail-0.3.5.jar')
     implementation 'ch.qos.logback:logback-classic:1.2.11'
     implementation 'ch.qos.logback:logback-core:1.2.11'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.5'

--- a/examples/gradle/build.gradle
+++ b/examples/gradle/build.gradle
@@ -4,10 +4,11 @@ plugins {
 
 repositories {
     mavenCentral()
+    mavenLocal()
 }
 
 dependencies {
-    implementation 'com.logtail:logback-logtail:0.3.4'
+    implementation files('../../target/logback-logtail-0.3.4.jar')
     implementation 'ch.qos.logback:logback-classic:1.2.11'
     implementation 'ch.qos.logback:logback-core:1.2.11'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.5'

--- a/examples/gradle/build.gradle
+++ b/examples/gradle/build.gradle
@@ -4,11 +4,10 @@ plugins {
 
 repositories {
     mavenCentral()
-    mavenLocal()
 }
 
 dependencies {
-    implementation files('../../target/logback-logtail-0.3.5.jar')
+    implementation 'com.logtail:logback-logtail:0.3.5'
     implementation 'ch.qos.logback:logback-classic:1.2.11'
     implementation 'ch.qos.logback:logback-core:1.2.11'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.5'

--- a/examples/gradle/src/main/java/com/logtail/example/App.java
+++ b/examples/gradle/src/main/java/com/logtail/example/App.java
@@ -4,72 +4,41 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
+import java.awt.Point;
 import java.time.Instant;
-import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Random;
+import java.util.UUID;
 
-/**
- * Reproduces ConcurrentModificationException in LogtailAppender.
- *
- * The race condition occurs when:
- * 1. Multiple threads call logger.info() which adds to the batch Vector
- * 2. The flush thread calls batchToJson() which iterates over batch.subList()
- * 3. During iteration, another thread modifies the batch via add()
- */
 public class App {
-    private static final Logger logger = LoggerFactory.getLogger(App.class);
-    private static final AtomicInteger errorCount = new AtomicInteger(0);
+    public static void main(String[] args) {
+        Logger logger = LoggerFactory.getLogger(App.class);
 
-    public static void main(String[] args) throws InterruptedException {
-        System.out.println("Starting ConcurrentModificationException reproduction test...");
-        System.out.println("Running multiple iterations to trigger the race condition.");
-        System.out.println();
+        MDC.put("requestId", UUID.randomUUID().toString());
+        MDC.put("requestTime", Long.toString(Instant.now().getEpochSecond()));
 
-        // Run multiple iterations to increase chance of hitting the race
-        for (int iteration = 0; iteration < 5; iteration++) {
-            System.out.println("=== Iteration " + (iteration + 1) + " ===");
-            runTest();
-            // Small pause between iterations
-            TimeUnit.MILLISECONDS.sleep(500);
+        logger.info("Hello World!");
+
+        Random coordinateGenerator = new Random();
+        logger.info("Point A", new Point(coordinateGenerator.nextInt(1024), coordinateGenerator.nextInt(1024)));
+        logger.info("Point B", new Point(coordinateGenerator.nextInt(1024), coordinateGenerator.nextInt(1024)));
+        logger.info("Point C", new Point(coordinateGenerator.nextInt(1024), coordinateGenerator.nextInt(1024)));
+
+        logger.info("Snow White met a few dwarfs.", "Doc", "Sleepy", "Dopey", "Grumpy", "Happy", "Bashful", "Sneezy");
+
+        try {
+            throw new RuntimeException("An error occurred.", new Exception("The original cause."));
+        } catch (RuntimeException exception) {
+            logger.error("Logging a thrown exception.", exception);
         }
 
-        System.out.println();
-        System.out.println("Test complete. If ConcurrentModificationException occurred,");
-        System.out.println("you would see ERROR logs with 'Error clearing X logs from batch'");
-        System.out.println("followed by 'Dropped batch of X logs.'");
+        logger.info("Logging local datetime serialized via JavaTimeModule.", LocalDateTime.now());
 
-        // Wait for final flushes
-        System.out.println();
-        System.out.println("Waiting 5 seconds for remaining flushes...");
-        TimeUnit.SECONDS.sleep(5);
-    }
-
-    private static void runTest() throws InterruptedException {
-        int threadCount = 1000;
-        int logsPerThread = 50;
-
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-
-        for (int t = 0; t < threadCount; t++) {
-            final int threadId = t;
-            executor.submit(() -> {
-                MDC.put("requestId", UUID.randomUUID().toString());
-                MDC.put("requestTime", Long.toString(Instant.now().getEpochSecond()));
-
-                for (int i = 0; i < logsPerThread; i++) {
-                    logger.info("Thread {} - Log message #{}", threadId, i);
-                }
-
-                MDC.clear();
-            });
+        try {
+            TimeUnit.SECONDS.sleep(5);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
         }
-
-        executor.shutdown();
-        executor.awaitTermination(30, TimeUnit.SECONDS);
-
-        System.out.println("Iteration completed: " + (threadCount * logsPerThread) + " logs attempted");
     }
 }

--- a/examples/gradle/src/main/java/com/logtail/example/App.java
+++ b/examples/gradle/src/main/java/com/logtail/example/App.java
@@ -4,41 +4,72 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
-import java.awt.Point;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.util.concurrent.TimeUnit;
-import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Reproduces ConcurrentModificationException in LogtailAppender.
+ *
+ * The race condition occurs when:
+ * 1. Multiple threads call logger.info() which adds to the batch Vector
+ * 2. The flush thread calls batchToJson() which iterates over batch.subList()
+ * 3. During iteration, another thread modifies the batch via add()
+ */
 public class App {
-    public static void main(String[] args) {
-        Logger logger = LoggerFactory.getLogger(App.class);
+    private static final Logger logger = LoggerFactory.getLogger(App.class);
+    private static final AtomicInteger errorCount = new AtomicInteger(0);
 
-        MDC.put("requestId", UUID.randomUUID().toString());
-        MDC.put("requestTime", Long.toString(Instant.now().getEpochSecond()));
+    public static void main(String[] args) throws InterruptedException {
+        System.out.println("Starting ConcurrentModificationException reproduction test...");
+        System.out.println("Running multiple iterations to trigger the race condition.");
+        System.out.println();
 
-        logger.info("Hello World!");
-
-        Random coordinateGenerator = new Random();
-        logger.info("Point A", new Point(coordinateGenerator.nextInt(1024), coordinateGenerator.nextInt(1024)));
-        logger.info("Point B", new Point(coordinateGenerator.nextInt(1024), coordinateGenerator.nextInt(1024)));
-        logger.info("Point C", new Point(coordinateGenerator.nextInt(1024), coordinateGenerator.nextInt(1024)));
-
-        logger.info("Snow White met a few dwarfs.", "Doc", "Sleepy", "Dopey", "Grumpy", "Happy", "Bashful", "Sneezy");
-
-        try {
-            throw new RuntimeException("An error occurred.", new Exception("The original cause."));
-        } catch (RuntimeException exception) {
-            logger.error("Logging a thrown exception.", exception);
+        // Run multiple iterations to increase chance of hitting the race
+        for (int iteration = 0; iteration < 5; iteration++) {
+            System.out.println("=== Iteration " + (iteration + 1) + " ===");
+            runTest();
+            // Small pause between iterations
+            TimeUnit.MILLISECONDS.sleep(500);
         }
 
-        logger.info("Logging local datetime serialized via JavaTimeModule.", LocalDateTime.now());
+        System.out.println();
+        System.out.println("Test complete. If ConcurrentModificationException occurred,");
+        System.out.println("you would see ERROR logs with 'Error clearing X logs from batch'");
+        System.out.println("followed by 'Dropped batch of X logs.'");
 
-        try {
-            TimeUnit.SECONDS.sleep(5);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+        // Wait for final flushes
+        System.out.println();
+        System.out.println("Waiting 5 seconds for remaining flushes...");
+        TimeUnit.SECONDS.sleep(5);
+    }
+
+    private static void runTest() throws InterruptedException {
+        int threadCount = 1000;
+        int logsPerThread = 50;
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+
+        for (int t = 0; t < threadCount; t++) {
+            final int threadId = t;
+            executor.submit(() -> {
+                MDC.put("requestId", UUID.randomUUID().toString());
+                MDC.put("requestTime", Long.toString(Instant.now().getEpochSecond()));
+
+                for (int i = 0; i < logsPerThread; i++) {
+                    logger.info("Thread {} - Log message #{}", threadId, i);
+                }
+
+                MDC.clear();
+            });
         }
+
+        executor.shutdown();
+        executor.awaitTermination(30, TimeUnit.SECONDS);
+
+        System.out.println("Iteration completed: " + (threadCount * logsPerThread) + " logs attempted");
     }
 }

--- a/examples/gradle/src/main/resources/logback.xml
+++ b/examples/gradle/src/main/resources/logback.xml
@@ -6,9 +6,6 @@
         <mdcFields>requestId,requestTime</mdcFields>
         <mdcTypes>string,int</mdcTypes>
         <objectMapperModule>com.fasterxml.jackson.datatype.jsr310.JavaTimeModule</objectMapperModule>
-        <!-- Small batch size to trigger frequent flushes and reproduce race condition -->
-        <batchSize>10</batchSize>
-        <batchInterval>100</batchInterval>
     </appender>
 
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">

--- a/examples/gradle/src/main/resources/logback.xml
+++ b/examples/gradle/src/main/resources/logback.xml
@@ -2,6 +2,7 @@
     <appender name="Logtail" class="com.logtail.logback.LogtailAppender">
         <appName>Better Stack Gradle example app</appName>
         <sourceToken><!-- YOUR SOURCE TOKEN --></sourceToken>
+        <ingestUrl>https://<!-- YOUR INGESTING HOST --></ingestUrl>
         <mdcFields>requestId,requestTime</mdcFields>
         <mdcTypes>string,int</mdcTypes>
         <objectMapperModule>com.fasterxml.jackson.datatype.jsr310.JavaTimeModule</objectMapperModule>

--- a/examples/gradle/src/main/resources/logback.xml
+++ b/examples/gradle/src/main/resources/logback.xml
@@ -6,6 +6,9 @@
         <mdcFields>requestId,requestTime</mdcFields>
         <mdcTypes>string,int</mdcTypes>
         <objectMapperModule>com.fasterxml.jackson.datatype.jsr310.JavaTimeModule</objectMapperModule>
+        <!-- Small batch size to trigger frequent flushes and reproduce race condition -->
+        <batchSize>10</batchSize>
+        <batchInterval>100</batchInterval>
     </appender>
 
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">

--- a/examples/maven/pom.xml
+++ b/examples/maven/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.logtail</groupId>
             <artifactId>logback-logtail</artifactId>
-            <version>0.3.4</version>
+            <version>0.3.5</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/examples/maven/src/main/resources/logback.xml
+++ b/examples/maven/src/main/resources/logback.xml
@@ -2,6 +2,7 @@
     <appender name="Logtail" class="com.logtail.logback.LogtailAppender">
         <appName>Better Stack Maven example app</appName>
         <sourceToken><!-- YOUR SOURCE TOKEN --></sourceToken>
+        <ingestUrl>https://<!-- YOUR INGESTING HOST --></ingestUrl>
         <mdcFields>requestId,requestTime</mdcFields>
         <mdcTypes>string,int</mdcTypes>
         <objectMapperModule>com.fasterxml.jackson.datatype.jsr310.JavaTimeModule</objectMapperModule>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <groupId>com.logtail</groupId>
     <artifactId>logback-logtail</artifactId>
     <packaging>jar</packaging>
-    <version>0.3.4</version>
+    <version>0.3.5</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Logback Java appender for sending logs to BetterStack.com</description>


### PR DESCRIPTION
Under heavy logging loads, ConcurrentModificationException might have appeared.

Managed to reproduce the issue, synchronize the queue modifications to make the atomic, and verified the issue is resolved. Planning on releasing as `v0.3.5`.